### PR TITLE
Orient docs toward hiring & scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Stratum: A Meta-Skill Framework for Building Great Teams
+# Stratum: A Leadership Framework for Hiring, Evaluating, and Scaling Elite Teams
 
-**Stratum** is a leadership framework designed for individuals and teams seeking to master the invisible skills that power high-performance collaboration. It helps you identify, evaluate, and grow the foundational behaviors behind clarity, resilience, trust, and influence.
+**Stratum** is a leadership framework for building elite teams. It focuses on hiring the right people, evaluating them on core meta-skills, and scaling a culture of trust and clarity. Use it to identify, assess, and grow the behaviors behind outstanding collaboration.
 
-This repository includes three fully scaffolded meta-skill domains, along with tactical tools, simulations, and flywheel case studies that bring them to life in real-world teams.
+This repository includes three fully scaffolded meta-skill domains, along with tactical tools, interview simulations, and flywheel case studies that bring them to life in real-world teams.
 
 > **Why Stratum?**
 > Because great teams aren't built on tactics—they’re built on thinking, character, and trust, practiced daily.
@@ -74,20 +74,19 @@ Each domain includes 5 meta-skills, foundational documents, tactical playbooks, 
 
 ## 🧭 How to Use Stratum
 
-### For Individuals:
-- Diagnose your growth edges with the domain diagnostics
-- Practice weekly using simulation decks and journaling from field notes
-- Reflect using flywheels to trace your real-time behavior under pressure
+### During Hiring
+- Apply the domain [Diagnostics](./evaluation-tools/cognitive-mastery-diagnostic.md) and [Scenario Decks](./scenario-templates/cognitive-scenarios.md) as advanced interview tools.
+- Evaluate candidates against the [Meta-Skill Framework](./framework/overview.md) to surface strengths and gaps.
 
-### For Leaders:
-- Use diagnostic tools in 1:1s, team offsites, or calibration sessions
-- Facilitate simulations to surface real decision habits in a safe space
-- Reinforce field notes as team rituals and micro-habits
+### Team Evaluation
+- Run diagnostics regularly to measure progress and spot coaching opportunities.
+- Debrief real projects using the flywheel case studies.
+- Reinforce growth areas through the field notes and playbooks.
 
-### For Coaches:
-- Run multi-domain assessments and debriefs for founders, leaders, or teams
-- Coach meta-skill stacks relevant to the leader’s current challenge (e.g. patience + influence)
-- Use flywheels to unpack real-world moments with high fidelity
+### Scaling Your Team
+- Establish rituals from the playbooks so culture scales with headcount.
+- Use meta-skill flywheels to onboard new hires quickly.
+- Revisit diagnostics each quarter to keep hiring standards high.
 
 ---
 

--- a/framework/character-core.md
+++ b/framework/character-core.md
@@ -1,7 +1,7 @@
 # Domain: Character Core
 
 ## What is Character Core?
-**Character Core** is the internal strength that enables composure, courage, and clarity in moments of stress, uncertainty, and pressure. It is the invisible force that steadies action when fear, ego, or fatigue threaten to derail it.
+**Character Core** is the internal strength that enables composure, courage, and clarity in moments of stress, uncertainty, and pressure. It is the invisible force that steadies action when fear, ego, or fatigue threaten to derail it. Evaluating for Character Core helps you see how a candidate will show up when the stakes are high.
 
 This domain reflects not just what a person can do—but who they choose to be when it matters.
 

--- a/framework/cognitive-mastery.md
+++ b/framework/cognitive-mastery.md
@@ -1,7 +1,7 @@
 # Domain: Cognitive Mastery
 
 ## What is Cognitive Mastery?
-**Cognitive Mastery** is the ability to think clearly, decide effectively, and learn rapidly—especially under pressure. It is the mental core of high-performance work.
+**Cognitive Mastery** is the ability to think clearly, decide effectively, and learn rapidly—especially under pressure. It is the mental core of high-performance work. When hiring, Cognitive Mastery signals how well someone will navigate ambiguous problems.
 
 This domain is what distinguishes elite strategists, resilient founders, and product thinkers. It doesn't just enable smart thinking—it enables **forward movement when the path isn’t clear**.
 

--- a/framework/overview.md
+++ b/framework/overview.md
@@ -1,1 +1,18 @@
  
+# Overview: Hiring, Evaluating & Scaling Elite Teams
+
+Stratum organizes team growth into a simple loop:
+
+1. **Hire for Meta-Skills**
+   - Use the [Diagnostics](../evaluation-tools/cognitive-mastery-diagnostic.md) and [Scenario Decks](../scenario-templates/cognitive-scenarios.md) as part of your interview process.
+   - Look for evidence of the behaviors described in the [Meta-Skill Domains](./cognitive-mastery.md).
+
+2. **Evaluate & Develop**
+   - Run diagnostics regularly and debrief using the [Flywheel Case Studies](./cognitive-mastery-flywheel.md).
+   - Reinforce strengths with the [Field Notes](../coaching-playbook/cognitive-field-notes.md) and other playbooks.
+
+3. **Scale with Trust**
+   - Apply the [Character Core](./character-core.md) and [Trust Dynamics](./trust-dynamics.md) guides to build a culture that scales.
+   - Revisit diagnostics each quarter to keep standards high as your team grows.
+
+Following this cycle keeps hiring rigorous, evaluation consistent, and growth sustainable.

--- a/framework/trust-dynamics.md
+++ b/framework/trust-dynamics.md
@@ -1,7 +1,7 @@
 # Domain: Trust Dynamics
 
 ## What is Trust Dynamics?
-**Trust Dynamics** is the domain of influence, alignment, communication, and collaboration. It governs how trust is earned, transferred, repaired, and expanded within teams and across systems.
+**Trust Dynamics** is the domain of influence, alignment, communication, and collaboration. It governs how trust is earned, transferred, repaired, and expanded within teams and across systems. Scaling teams depends on the invisible trust flows this domain makes explicit.
 
 This domain isn't about being liked—it's about being trusted, understood, and followed when it counts.
 


### PR DESCRIPTION
## Summary
- position Stratum as a leadership system for hiring, evaluating and scaling elite teams
- outline hiring/evaluation/scale loop in `framework/overview.md`
- adjust domain guides to mention hiring impact

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3bcfdb908323a86e05add87ce0a8