### PR TITLE
Align CLI scoring with docs

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -84,11 +84,11 @@ async function runDiagnostics() {
   const content = fs.readFileSync(file, 'utf8');
   const sections = parseDiagnostic(content);
 
-  let total = 0;
   console.log(`\n${domain} Diagnostic`);
 
   for (const sec of sections) {
     console.log(`\n${sec.skill}`);
+    let secTotal = 0;
     for (const statement of sec.statements) {
       const { score } = await inquirer.prompt({
         type: 'input',
@@ -96,18 +96,17 @@ async function runDiagnostics() {
         message: `${statement} (1-5)`,
         validate: v => /^[1-5]$/.test(v) || 'Enter a number 1-5'
       });
-      total += parseInt(score, 10);
+      secTotal += parseInt(score, 10);
     }
+    const interpretation = interpretScore(secTotal);
+    console.log(`Score: ${secTotal} - ${interpretation}`);
   }
-
-  const interpretation = interpretScore(total);
-  console.log(`\nTotal Score: ${total}\n${interpretation}\n`);
 }
 
 function interpretScore(score) {
-  if (score >= 105) return 'Deep strength – anchors trust and alignment in systems';
-  if (score >= 80) return 'Solid foundation – influence and clarity are consistently felt';
-  if (score >= 55) return 'Functional but uneven – watch for blind spots under pressure';
+  if (score >= 21) return 'Deep strength – anchors trust and alignment in systems';
+  if (score >= 16) return 'Solid foundation – influence and clarity are consistently felt';
+  if (score >= 11) return 'Functional but uneven – watch for blind spots under pressure';
   return 'Growth area – may erode trust without intention or clarity';
 }
 

--- a/evaluation-tools/character-core-diagnostic.md
+++ b/evaluation-tools/character-core-diagnostic.md
@@ -56,6 +56,9 @@ Rate each statement on a scale of **1 (Strongly Disagree)** to **5 (Strongly Agr
 
 ## Scoring Guidance
 
+Add together the five ratings under each skill to get a total out of **25**.
+Use the ranges below to understand your capability for that skill.
+
 | Score (per skill) | Interpretation |
 |------------------|----------------|
 | 21–25 | Deep capability – leads with character under pressure |

--- a/evaluation-tools/cognitive-mastery-diagnostic.md
+++ b/evaluation-tools/cognitive-mastery-diagnostic.md
@@ -54,7 +54,10 @@ Each section contains 5 statements (one per meta-skill). Rate each from **1 (Str
 
 ## Scoring Guidance
 
-### Total Score Ranges (Out of 25 per skill):
+Add up your ratings for the five statements under each skill. This gives a score
+out of **25** for that skill. Use the ranges below to interpret each skill's
+score:
+
 | Score | Interpretation |
 |-------|----------------|
 | 21–25 | Core strength – can coach others |

--- a/evaluation-tools/trust-dynamics-diagnostic.md
+++ b/evaluation-tools/trust-dynamics-diagnostic.md
@@ -56,6 +56,9 @@ Rate each statement on a scale of **1 (Strongly Disagree)** to **5 (Strongly Agr
 
 ## Scoring Guidance
 
+Sum the five ratings listed under each skill to get a score out of **25**. Apply
+the ranges below to gauge your current strength for that skill.
+
 | Score (per skill) | Interpretation |
 |------------------|----------------|
 | 21–25 | Deep strength – anchors trust and alignment in systems |


### PR DESCRIPTION
## Summary
- calculate a separate score for each skill in `cli/index.js`
- add per-skill score guidance in all diagnostic markdown files

## Testing
- `node --check cli/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68590ba02d308323844c23fae205b934