### PR TITLE
Add role-focused playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Each domain includes 5 meta-skills, foundational documents, tactical playbooks, 
 - [Character Core Field Notes](./coaching-playbook/character-field-notes.md)
 - [Trust Dynamics Field Notes](./coaching-playbook/trust-dynamics-field-notes.md)
 
+### 👥 Role Playbooks
+- [Engineering Playbook](./coaching-playbook/engineering/README.md)
+- [Product Playbook](./coaching-playbook/product/README.md)
+- [Operations Playbook](./coaching-playbook/operations/README.md)
+
 ### 🔁 Flywheel Case Studies
 - [Cognitive Mastery Flywheel](./meta-skills/cognitive-flywheel-case.md)
 - [Character Core Flywheel](./meta-skills/character-flywheel-case.md)

--- a/coaching-playbook/engineering/README.md
+++ b/coaching-playbook/engineering/README.md
@@ -1,0 +1,17 @@
+# Engineering Playbook
+
+Quick checklist for applying Stratum within engineering teams.
+
+## Key Meta-Skills
+- **First Principles Thinking** – break systems down to their fundamental parts.
+- **Scenario Thinking** – map failure paths before they become incidents.
+- **Execution with Reversibility** – ship in small steps and keep rollbacks ready.
+- **Confidence Calibration** – express uncertainty so decisions get better.
+- **Trust-Building** – deliver reliably and close loops quickly.
+
+## Team Rituals
+- Architecture reviews anchored in first principles.
+- Post-mortems focused on missed signals and lessons learned.
+- Use feature flags or kill switches on every major launch.
+- Hold a weekly "confidence round" on key technical decisions.
+- Pair reviews to spread knowledge and build trust across the team.

--- a/coaching-playbook/operations/README.md
+++ b/coaching-playbook/operations/README.md
@@ -1,0 +1,17 @@
+# Operations Playbook
+
+Quick checklist for operational leads using Stratum.
+
+## Key Meta-Skills
+- **Execution with Reversibility** – keep processes flexible and recoverable.
+- **Tribal Intelligence** – spot hidden blockers and influencers early.
+- **Resilience** – rebound fast when plans change.
+- **Decision-Making Under Uncertainty** – act with partial data.
+- **Trust-Building** – keep stakeholders confident in the plan.
+
+## Team Rituals
+- Daily priority check-ins with clear escalation paths.
+- Post-project debriefs to capture process lessons.
+- Maintain playbooks with reversible steps for critical workflows.
+- Review a stakeholder or tribal map every quarter.
+- Celebrate quick recoveries as much as smooth launches.

--- a/coaching-playbook/product/README.md
+++ b/coaching-playbook/product/README.md
@@ -1,0 +1,17 @@
+# Product Playbook
+
+Quick checklist for product leaders using Stratum.
+
+## Key Meta-Skills
+- **Scenario Thinking** – design around multiple futures and edge cases.
+- **Narrative Framing** – keep teams aligned on meaning and momentum.
+- **Decision-Making Under Uncertainty** – choose progress over paralysis.
+- **Ability to Influence** – build support across functions.
+- **Feedback Calibration** – learn from every ship and update fast.
+
+## Team Rituals
+- Start each kickoff with a "why this matters now" framing.
+- Weekly roadmap check that includes scenario reviews.
+- Prewire major decisions with cross-functional stakeholders.
+- After launches, run a feedback debrief to update assumptions.
+- Maintain a living backlog with explicit confidence levels.


### PR DESCRIPTION
## Summary
- add Engineering, Product, and Operations playbooks under `coaching-playbook/`
- link the new role playbooks in README for easy onboarding

## Testing
- `npm install`
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_6874f53ec00c8323852c4bc0da69232f